### PR TITLE
fix: usp + sparse attn in wan2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ spas_sage_attn.egg-info
 /build
 *.so
 .DS_Store
+*.mp4

--- a/evaluate/wan_example.py
+++ b/evaluate/wan_example.py
@@ -89,7 +89,8 @@ def _parse_args():
     parser.add_argument(
         "--size",
         type=str,
-        default="1280*720",
+        # default="1280*720",
+        default="832*480",
         choices=list(SIZE_CONFIGS.keys()),
         help="The area (width*height) of the generated video. For the I2V task, the aspect ratio of the output video will follow that of the input image."
     )
@@ -313,7 +314,7 @@ def generate(args):
         )
         
         if args.use_spas_sage_attn:
-            set_spas_sage_attn_wan(wan_t2v.model, verbose=args.verbose, l1=args.l1, pv_l1=args.pv_l1, tune_pv=args.tune_pv)
+            set_spas_sage_attn_wan(wan_t2v.model, verbose=args.verbose, l1=args.l1, pv_l1=args.pv_l1, tune_pv=args.tune_pv, use_usp=(args.ulysses_size > 1 or args.ring_size > 1))
             if not args.tune:
                 saved_state_dict = torch.load(args.model_out_path)
                 load_sparse_attention_state_dict(wan_t2v.model, saved_state_dict)
@@ -385,7 +386,7 @@ def generate(args):
         )
         
         if args.use_spas_sage_attn:
-            set_spas_sage_attn_wan(wan_i2v.model, verbose=args.verbose, l1=args.l1, pv_l1=args.pv_l1, tune_pv=args.tune_pv)
+            set_spas_sage_attn_wan(wan_i2v.model, verbose=args.verbose, l1=args.l1, pv_l1=args.pv_l1, tune_pv=args.tune_pv, use_usp=(args.ulysses_size > 1 or args.ring_size > 1))
             if not args.tune:
                 saved_state_dict = torch.load(args.model_out_path)
                 load_sparse_attention_state_dict(wan_i2v.model, saved_state_dict)

--- a/spas_sage_attn/autotune.py
+++ b/spas_sage_attn/autotune.py
@@ -33,7 +33,10 @@ def load_sparse_attention_state_dict(model, saved_state_dict, multigpu=False, ve
                     if verbose: print(f'{sk} is a substate_dict of {k}, we will load it.')
                     sub_name = sk.split(k)[1][1:]
                     if multigpu:
-                        sv= sv.to(device=v.device)
+                        try:
+                            sv = sv.to(device=v.device)
+                        except AttributeError:
+                            sv = sv.to(device=f"cuda:{torch.cuda.current_device()}")
                     else:
                         sv = sv.to(device=device, dtype=dtype)
                     setattr(v, sub_name, nn.Parameter(sv, requires_grad=False))

--- a/spas_sage_attn/core.py
+++ b/spas_sage_attn/core.py
@@ -74,7 +74,7 @@ def spas_sage2_attn_meansim_cuda(q, k, v, attn_mask=None, dropout_p=0.0, is_caus
     if scale is None:
         scale = 1.0 / (headdim ** 0.5)
 
-    assert headdim in [64, 128], "headdim should be in [64, 96, 128]."
+    assert headdim in [64, 96, 128], "headdim should be in [64, 96, 128]."
 
     pvthreshd = hyperparameter_check(pvthreshd, q.size(-3), q.device)
 


### PR DESCRIPTION
It seems that you have not implemented usp + sparse attn successfully.
In wan repo, usp was implemented by replace self_attn.forward func, the same way as implementation of sparse sage attn in the repo. So the usp implementation is overridden.
Causes the following error:
#34 