### PR TITLE
Add cassert in build flags to support Hopper + CUDA 12.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ NVCC_FLAGS = [
     "--threads=8",
     "-Xptxas=-v",
     "-diag-suppress=174", # suppress the specific warning
+    "-Xcompiler", "-include,cassert", # fix error occurs when compiling for SM90+ with newer CUDA toolkits
 ]
 
 ABI = 1 if torch._C._GLIBCXX_USE_CXX11_ABI else 0


### PR DESCRIPTION
Add the following flag to resolve the '__assert_fail' undefined error. This error occurs when compiling for SM90+ with newer CUDA toolkits (tested on 12.8) because the <cassert> header is not automatically included. This flag forces the host compiler (like g++) to include it for every .cu file.