### PR TITLE
feat: provide block-sparse API with any block-sparse pattern per head.

### DIFF
--- a/csrc/mma.cuh
+++ b/csrc/mma.cuh
@@ -22,7 +22,6 @@
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 #include <type_traits>
-#include <stdio.h>
 #include <assert.h>
 
 namespace mma{
@@ -57,7 +56,9 @@ namespace mma{
 #if defined(__CUDA_ARCH__)
 #define RUNTIME_ASSERT(x) __brkpt()
 #else
-#define RUNTIME_ASSERT(x) printf("%s\n",x);exit(-1)
+//#include <assert.h>
+#define RUNTIME_ASSERT(x) assert(0 && x)
+//#define RUNTIME_ASSERT(x) ((void)0)
 #endif
 
 enum class MMAMode {

--- a/csrc/numeric_conversion.cuh
+++ b/csrc/numeric_conversion.cuh
@@ -22,7 +22,6 @@
 #include <cuda_fp8.h>
 #include <cuda_runtime.h>
 #include <cuda/pipeline>
-#include <stdio.h>
 #include <assert.h>
 
 #if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120400)
@@ -34,7 +33,7 @@
 #if defined(__CUDA_ARCH__)
 #define RUNTIME_ASSERT(x) __brkpt()
 #else
-#define RUNTIME_ASSERT(x) printf("%s\n",x);exit(-1)
+//#include <assert.h>
 #define RUNTIME_ASSERT(x) assert(0 && x)
 //#define RUNTIME_ASSERT(x) ((void)0)
 #endif

--- a/csrc/qattn/qk_int_sv_f8_cuda_sm90.cuh
+++ b/csrc/qattn/qk_int_sv_f8_cuda_sm90.cuh
@@ -19,7 +19,6 @@
 #include <cuda_bf16.h>
 #include <cuda_fp8.h>
 #include <cassert>
-#include <stdio.h>
 
 #include "../wgmma.cuh"
 #include "../math.cuh"
@@ -33,13 +32,9 @@
 #if defined(__CUDA_ARCH__)
 #define RUNTIME_ASSERT(x) __brkpt()
 #else
-<<<<<<< HEAD
-#define RUNTIME_ASSERT(x) printf("%s\n",x);exit(-1)
-=======
 //#include <assert.h>
 #define RUNTIME_ASSERT(x) assert(0 && x)
 //#define RUNTIME_ASSERT(x) ((void)0)
->>>>>>> upstream/main
 #endif
 
 template <int BlockMajorSize, int BlockMinorSize, bool swizzle=true, CUtensorMapL2promotion_enum promotion_mode=CU_TENSOR_MAP_L2_PROMOTION_NONE, typename T>

--- a/csrc/wgmma.cuh
+++ b/csrc/wgmma.cuh
@@ -16,7 +16,6 @@
 
 #pragma once
 #include <cuda.h>
-#include <stdio.h>
 #include <assert.h>
 
 namespace wgmma{
@@ -27,7 +26,9 @@ namespace wgmma{
 #if defined(__CUDA_ARCH__)
 #define RUNTIME_ASSERT(x) __brkpt()
 #else
-#define RUNTIME_ASSERT(x) printf("%s\n",x);exit(-1)
+// #include <assert.h>
+#define RUNTIME_ASSERT(x) assert(0 && x)
+//#define RUNTIME_ASSERT(x) ((void)0)
 #endif
 
 __device__ __forceinline__ uint64_t matrix_descriptor_encode(uint64_t x) { return (((x) & 0x3FFFF) >> 0x4); }


### PR DESCRIPTION
In this PR, we support the following API:

```python
from spas_sage_attn import block_sparse_sage2_attn_cuda

block_sparse_sage2_attn_cuda(q, k, v, mask_id=None, dropout_p=0.0, scale=None, smooth_k=True, pvthreshd=50, attention_sink=False, tensor_layout="HND", output_dtype=torch.float16, return_sparsity=False):
```

Specifically, we use `mask_id` to guide the sparsity pattern for each attention head during the $QK^T$ multiplication process. For $PV$ multiplication, we also adopt the threshold judgement policy in [Sparge Attention paper](https://arxiv.org/pdf/2502.18137).