### PR TITLE
fixed the compiling error of assert when using CUDA 12.8

### DIFF
--- a/csrc/mma.cuh
+++ b/csrc/mma.cuh
@@ -49,8 +49,9 @@ namespace mma{
 #if defined(__CUDA_ARCH__)
 #define RUNTIME_ASSERT(x) __brkpt()
 #else
-#include <assert.h>
-#define RUNTIME_ASSERT(x) assert(0 && x)
+//#include <assert.h>
+//#define RUNTIME_ASSERT(x) assert(0 && x)
+#define RUNTIME_ASSERT(x) ((void)0)
 #endif
 
 enum class MMAMode {

--- a/csrc/numeric_conversion.cuh
+++ b/csrc/numeric_conversion.cuh
@@ -32,8 +32,9 @@
 #if defined(__CUDA_ARCH__)
 #define RUNTIME_ASSERT(x) __brkpt()
 #else
-#include <assert.h>
-#define RUNTIME_ASSERT(x) assert(0 && x)
+//#include <assert.h>
+//#define RUNTIME_ASSERT(x) assert(0 && x)
+#define RUNTIME_ASSERT(x) ((void)0)
 #endif
 
 __device__ __forceinline__ void floatx4_to_e4m3x4(uint32_t *dest, float *source0, float *source1)

--- a/csrc/qattn/qk_int_sv_f8_cuda_sm90.cuh
+++ b/csrc/qattn/qk_int_sv_f8_cuda_sm90.cuh
@@ -31,8 +31,9 @@
 #if defined(__CUDA_ARCH__)
 #define RUNTIME_ASSERT(x) __brkpt()
 #else
-#include <assert.h>
-#define RUNTIME_ASSERT(x) assert(0 && x)
+//#include <assert.h>
+//#define RUNTIME_ASSERT(x) assert(0 && x)
+#define RUNTIME_ASSERT(x) ((void)0)
 #endif
 
 template <int BlockMajorSize, int BlockMinorSize, bool swizzle=true, CUtensorMapL2promotion_enum promotion_mode=CU_TENSOR_MAP_L2_PROMOTION_NONE, typename T>

--- a/csrc/wgmma.cuh
+++ b/csrc/wgmma.cuh
@@ -25,8 +25,9 @@ namespace wgmma{
 #if defined(__CUDA_ARCH__)
 #define RUNTIME_ASSERT(x) __brkpt()
 #else
-#include <assert.h>
-#define RUNTIME_ASSERT(x) assert(0 && x)
+// #include <assert.h>
+// #define RUNTIME_ASSERT(x) assert(0 && x)
+#define RUNTIME_ASSERT(x) ((void)0)
 #endif
 
 __device__ __forceinline__ uint64_t matrix_descriptor_encode(uint64_t x) { return (((x) & 0x3FFFF) >> 0x4); }


### PR DESCRIPTION
the `#include <assert.h>` in namespace could cause compiling error in CUDA 12.8, remove the `#define RUNTIME_ASSERT` in the namespace.