### PR TITLE
feat: solve tuning OOM in cogvideo_example.py

### DIFF
--- a/evaluate/cogvideo_example.py
+++ b/evaluate/cogvideo_example.py
@@ -71,6 +71,9 @@ if __name__ == "__main__":
             torch_dtype=dtype_,
         ).to(device)
 
+        pipe.vae.enable_slicing()
+        pipe.vae.enable_tiling()
+
         pipe.enable_model_cpu_offload()
 
         for i, prompt in tqdm(enumerate(prompts[:5])):


### PR DESCRIPTION
We solve the OOM error during tuning by adding:
```python
pipe.vae.enable_slicing()
pipe.vae.enable_tiling()
```
in the tuning code of `cogvideo_example.py`.