### PR TITLE
fix: UnboundLocalError when smooth_k=False

### DIFF
--- a/spas_sage_attn/core.py
+++ b/spas_sage_attn/core.py
@@ -50,6 +50,7 @@ def spas_sage2_attn_meansim_cuda(q, k, v, attn_mask=None, dropout_p=0.0, is_caus
     else:
         q, k, v = q.contiguous().to(torch.bfloat16), k.contiguous().to(torch.bfloat16), v.contiguous().to(torch.float16)
 
+    km = None
     if smooth_k:
         km = k.mean(dim=-2, keepdim=True)
         # k = k - km
@@ -116,6 +117,7 @@ def spas_sage2_attn_meansim_topk_cuda(q, k, v, attn_mask=None, dropout_p=0.0, is
     else:
         q, k, v = q.contiguous().to(torch.bfloat16), k.contiguous().to(torch.bfloat16), v.contiguous().to(torch.float16)
 
+    km = None
     if smooth_k:
         km = k.mean(dim=-2, keepdim=True)
         # k = k - km
@@ -182,6 +184,7 @@ def block_sparse_sage2_attn_cuda(q, k, v, mask_id=None, dropout_p=0.0, scale=Non
     else:
         q, k, v = q.contiguous().to(torch.bfloat16), k.contiguous().to(torch.bfloat16), v.contiguous().to(torch.float16)
 
+    km = None
     if smooth_k:
         km = k.mean(dim=-2, keepdim=True)
         # k = k - km
@@ -246,6 +249,7 @@ def spas_sage_attn_meansim_cuda(q, k, v, attn_mask=None, dropout_p=0.0, is_causa
     else:
         q, k, v = q.contiguous().to(torch.bfloat16), k.contiguous().to(torch.bfloat16), v.contiguous().to(torch.float16)
 
+    km = None
     if smooth_k:
         km = k.mean(dim=-2, keepdim=True)
         # k = k - km
@@ -289,6 +293,7 @@ def spas_sage_attn_meansim_topk_cuda(q, k, v, attn_mask=None, dropout_p=0.0, is_
     else:
         q, k, v = q.contiguous().to(torch.bfloat16), k.contiguous().to(torch.bfloat16), v.contiguous().to(torch.float16)
 
+    km = None
     if smooth_k:
         km = k.mean(dim=-2, keepdim=True)
         # k = k - km


### PR DESCRIPTION
`km` is assigned only inside `if smooth_k:` and then used unconditionally a few lines later, so every entry point raises as soon as a caller passes `smooth_k=False`:

```
UnboundLocalError: cannot access local variable 'km' where it is not associated with a value
```

Five functions are affected — `spas_sage2_attn_meansim_cuda`, `spas_sage2_attn_meansim_topk_cuda`, `block_sparse_sage2_attn_cuda`, `spas_sage_attn_meansim_cuda`, `spas_sage_attn_meansim_topk_cuda`.

## Why this is reachable in normal use

ComfyUI builds its SageAttention kwargs with `smooth_k=False` (`comfy/ldm/modules/attention.py`), so dropping SpargeAttn in behind that entry point fails on the very first call.

The failure is quiet, which is the part worth flagging. ComfyUI catches the exception and falls back to PyTorch attention with a single logged line:

```
ERROR: Error running sage attention: cannot access local variable 'km' where it is not
associated with a value, using pytorch attention instead.
```

So a user who wires SpargeAttn in this way ends up **slower than plain SageAttention** while believing the sparse kernel is active. I hit exactly this while benchmarking on a 3090 and only noticed because the speedup was missing.

## The fix

Initialise `km = None` before the branch. That is already the value the consumers expect for "no smoothing" — both `get_vanilla_qk_quant` and `get_block_map_meansim_fuse_quant` declare

```python
km: Optional[torch.Tensor] = None
```

and guard with `if km is not None`, so the None path is supported and nothing downstream needs to change. Five added lines, no behaviour change when `smooth_k=True`.

## Verification

RTX 3090 (sm_86), CUDA 13.0, torch 2.13, compared against `scaled_dot_product_attention` on identical inputs:

| | `smooth_k=False` | `smooth_k=True` |
| - | - | - |
| before | `UnboundLocalError` | runs |
| after — `meansim` | runs, relL2 0.0129 | runs, relL2 0.0131 |
| after — `meansim_topk` | runs, relL2 0.9793 | runs, relL2 0.9792 |

Two notes on reading that table, so the numbers are not mistaken for something they are not:

- The two `smooth_k` settings agreeing closely is expected here rather than evidence the flag is ignored. The inputs are random, so `k.mean(dim=-2)` is approximately zero and subtracting it changes almost nothing. A real activation distribution is where smoothing earns its keep.
- The `topk` rows are far from SDPA because the default `topk=0.5` discards half the blocks. That is the kernel doing its job, not error introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
